### PR TITLE
Implement some interceptors to override base urls

### DIFF
--- a/trip-kit/src/main/java/com/skedgo/android/tripkit/BaseUrlOverridingInterceptor.java
+++ b/trip-kit/src/main/java/com/skedgo/android/tripkit/BaseUrlOverridingInterceptor.java
@@ -1,0 +1,42 @@
+package com.skedgo.android.tripkit;
+
+import android.support.annotation.NonNull;
+import android.text.TextUtils;
+
+import java.io.IOException;
+import java.util.List;
+
+import okhttp3.HttpUrl;
+import okhttp3.Interceptor;
+import okhttp3.Request;
+import okhttp3.Response;
+import rx.functions.Func0;
+
+final class BaseUrlOverridingInterceptor implements Interceptor {
+  private final Func0<String> baseUrlAdapter;
+
+  BaseUrlOverridingInterceptor(@NonNull Func0<String> baseUrlAdapter) {
+    this.baseUrlAdapter = baseUrlAdapter;
+  }
+
+  @Override public Response intercept(Chain chain) throws IOException {
+    final String newBaseUrl = baseUrlAdapter.call();
+    final Request request = chain.request();
+    final HttpUrl requestUrl = request.url();
+    final List<String> pathSegments = requestUrl.pathSegments();
+    if (!TextUtils.isEmpty(newBaseUrl) && pathSegments.get(0).equals("satapp")) {
+      final HttpUrl tempUrl = requestUrl.newBuilder().removePathSegment(0).build();
+      final String query = tempUrl.query();
+      final String encodedPath = TextUtils.join("/", tempUrl.encodedPathSegments());
+      final HttpUrl newUrl = HttpUrl.parse(newBaseUrl)
+          .newBuilder()
+          .addEncodedPathSegments(encodedPath)
+          .query(query)
+          .build();
+      final Request newRequest = request.newBuilder().url(newUrl).build();
+      return chain.proceed(newRequest);
+    } else {
+      return chain.proceed(request);
+    }
+  }
+}

--- a/trip-kit/src/main/java/com/skedgo/android/tripkit/BaseUrlOverridingInterceptorCompat.java
+++ b/trip-kit/src/main/java/com/skedgo/android/tripkit/BaseUrlOverridingInterceptorCompat.java
@@ -1,0 +1,47 @@
+package com.skedgo.android.tripkit;
+
+import android.support.annotation.NonNull;
+import android.text.TextUtils;
+
+import com.squareup.okhttp.HttpUrl;
+import com.squareup.okhttp.Interceptor;
+import com.squareup.okhttp.OkHttpClient;
+import com.squareup.okhttp.Request;
+import com.squareup.okhttp.Response;
+
+import java.io.IOException;
+import java.util.List;
+
+import rx.functions.Func0;
+
+/**
+ * Provides capability of {@link BaseUrlOverridingInterceptor} for {@link OkHttpClient} (pre v3).
+ */
+final class BaseUrlOverridingInterceptorCompat implements Interceptor {
+  private final Func0<String> baseUrlAdapter;
+
+  BaseUrlOverridingInterceptorCompat(@NonNull Func0<String> baseUrlAdapter) {
+    this.baseUrlAdapter = baseUrlAdapter;
+  }
+
+  @Override public Response intercept(Chain chain) throws IOException {
+    final String newBaseUrl = baseUrlAdapter.call();
+    final Request request = chain.request();
+    final HttpUrl requestUrl = request.httpUrl();
+    final List<String> pathSegments = requestUrl.pathSegments();
+    if (!TextUtils.isEmpty(newBaseUrl) && pathSegments.get(0).equals("satapp")) {
+      final HttpUrl tempUrl = requestUrl.newBuilder().removePathSegment(0).build();
+      final String query = tempUrl.query();
+      final HttpUrl.Builder newBuilder = HttpUrl.parse(newBaseUrl).newBuilder();
+      for (String pathSegment : tempUrl.pathSegments()) {
+        newBuilder.addPathSegment(pathSegment);
+      }
+
+      final HttpUrl newUrl = newBuilder.query(query).build();
+      final Request newRequest = request.newBuilder().url(newUrl).build();
+      return chain.proceed(newRequest);
+    } else {
+      return chain.proceed(request);
+    }
+  }
+}

--- a/trip-kit/src/main/java/com/skedgo/android/tripkit/Configs.java
+++ b/trip-kit/src/main/java/com/skedgo/android/tripkit/Configs.java
@@ -25,6 +25,13 @@ public abstract class Configs {
   @Nullable public abstract Func0<Co2Preferences> co2PreferencesFactory();
   @Nullable public abstract Func0<TripPreferences> tripPreferencesFactory();
 
+  /**
+   * @return A factory to create a sort of adapter that specifies a base url
+   * to override all the 'satapp' requests made by TripKit's apis.
+   * The factory is in use only when {@link #debuggable()} is true.
+   */
+  @Nullable public abstract Func0<Func0<String>> baseUrlAdapterFactory();
+
   @Value.Default public boolean debuggable() {
     return false;
   }
@@ -37,6 +44,7 @@ public abstract class Configs {
     Builder excludedTransitModesAdapter(ExcludedTransitModesAdapter excludedTransitModesAdapter);
     Builder co2PreferencesFactory(Func0<Co2Preferences> co2PreferencesFactory);
     Builder tripPreferencesFactory(Func0<TripPreferences> tripPreferencesFactory);
+    Builder baseUrlAdapterFactory(Func0<Func0<String>> baseUrlAdapterFactory);
     Configs build();
   }
 }

--- a/trip-kit/src/test/java/com/skedgo/android/tripkit/BaseUrlOverridingInterceptorCompatTest.java
+++ b/trip-kit/src/test/java/com/skedgo/android/tripkit/BaseUrlOverridingInterceptorCompatTest.java
@@ -1,0 +1,108 @@
+package com.skedgo.android.tripkit;
+
+import com.squareup.okhttp.HttpUrl;
+import com.squareup.okhttp.Interceptor;
+import com.squareup.okhttp.Request;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentMatcher;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.robolectric.RobolectricGradleTestRunner;
+import org.robolectric.annotation.Config;
+
+import java.io.IOException;
+
+import rx.functions.Func0;
+
+import static org.mockito.Matchers.argThat;
+import static org.mockito.Matchers.same;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(RobolectricGradleTestRunner.class)
+@Config(constants = BuildConfig.class, sdk = 21)
+public class BaseUrlOverridingInterceptorCompatTest {
+  @Mock Func0<String> baseUrlAdapter;
+  private BaseUrlOverridingInterceptorCompat interceptor;
+
+  @Before public void before() {
+    MockitoAnnotations.initMocks(this);
+    interceptor = new BaseUrlOverridingInterceptorCompat(baseUrlAdapter);
+  }
+
+  @Test public void overrideSatappRequestWithoutQueryParams() throws IOException {
+    when(baseUrlAdapter.call()).thenReturn("https://granduni.buzzhives.com/satapp-beta/");
+
+    final Interceptor.Chain chain = mock(Interceptor.Chain.class);
+    final Request chainRequest = new Request.Builder()
+        .url("https://sydney-au-nsw-sydney.tripgo.skedgo.com/satapp/regions.json")
+        .build();
+    when(chain.request()).thenReturn(chainRequest);
+
+    final Request expectedRequest = chainRequest.newBuilder()
+        .url("https://granduni.buzzhives.com/satapp-beta/regions.json")
+        .build();
+    interceptor.intercept(chain);
+
+    verify(chain).proceed(argThat(new ArgumentMatcher<Request>() {
+      @Override public boolean matches(Object argument) {
+        final Request actualRequest = (Request) argument;
+        return actualRequest.url().equals(expectedRequest.url())
+            && actualRequest.method().equals(expectedRequest.method());
+      }
+    }));
+  }
+
+  @Test public void overrideSatappRequestWithQueryParams() throws IOException {
+    when(baseUrlAdapter.call()).thenReturn("https://granduni.buzzhives.com/satapp-beta/");
+
+    final Interceptor.Chain chain = mock(Interceptor.Chain.class);
+    final Request chainRequest = new Request.Builder()
+        .url(HttpUrl.parse("https://lepton-us-co-denver.tripgo.skedgo.com/satapp/routing.json?modes=ps_tax&v=11&arriveBefore=0&tt=0&departAfter=1459485056&version=a-beta4.5.1-debug"))
+        .build();
+    when(chain.request()).thenReturn(chainRequest);
+
+    final Request expectedRequest = chainRequest.newBuilder()
+        .url(HttpUrl.parse("https://granduni.buzzhives.com/satapp-beta/routing.json?modes=ps_tax&v=11&arriveBefore=0&tt=0&departAfter=1459485056&version=a-beta4.5.1-debug"))
+        .build();
+    interceptor.intercept(chain);
+
+    verify(chain).proceed(argThat(new ArgumentMatcher<Request>() {
+      @Override public boolean matches(Object argument) {
+        final Request actualRequest = (Request) argument;
+        return actualRequest.url().equals(expectedRequest.url())
+            && actualRequest.method().equals(expectedRequest.method());
+      }
+    }));
+  }
+
+  @Test public void ignoreNonSatappRequest() throws IOException {
+    when(baseUrlAdapter.call()).thenReturn("https://granduni.buzzhives.com/satapp-beta/");
+
+    final Interceptor.Chain chain = mock(Interceptor.Chain.class);
+    final Request chainRequest = new Request.Builder()
+        .url(HttpUrl.parse("https://skedgo.com/tripgo"))
+        .build();
+    when(chain.request()).thenReturn(chainRequest);
+
+    interceptor.intercept(chain);
+    verify(chain).proceed(same(chainRequest));
+  }
+
+  @Test public void ignoreIfNoNewBaseUrlAvailable() throws IOException {
+    when(baseUrlAdapter.call()).thenReturn(null);
+
+    final Interceptor.Chain chain = mock(Interceptor.Chain.class);
+    final Request chainRequest = new Request.Builder()
+        .url(HttpUrl.parse("https://skedgo.com/tripgo"))
+        .build();
+    when(chain.request()).thenReturn(chainRequest);
+
+    interceptor.intercept(chain);
+    verify(chain).proceed(same(chainRequest));
+  }
+}

--- a/trip-kit/src/test/java/com/skedgo/android/tripkit/BaseUrlOverridingInterceptorTest.java
+++ b/trip-kit/src/test/java/com/skedgo/android/tripkit/BaseUrlOverridingInterceptorTest.java
@@ -1,0 +1,107 @@
+package com.skedgo.android.tripkit;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentMatcher;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.robolectric.RobolectricGradleTestRunner;
+import org.robolectric.annotation.Config;
+
+import java.io.IOException;
+
+import okhttp3.HttpUrl;
+import okhttp3.Interceptor;
+import okhttp3.Request;
+import rx.functions.Func0;
+
+import static org.mockito.Matchers.argThat;
+import static org.mockito.Matchers.same;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(RobolectricGradleTestRunner.class)
+@Config(constants = BuildConfig.class, sdk = 21)
+public class BaseUrlOverridingInterceptorTest {
+  @Mock Func0<String> baseUrlAdapter;
+  private BaseUrlOverridingInterceptor interceptor;
+
+  @Before public void before() {
+    MockitoAnnotations.initMocks(this);
+    interceptor = new BaseUrlOverridingInterceptor(baseUrlAdapter);
+  }
+
+  @Test public void overrideSatappRequestWithoutQueryParams() throws IOException {
+    when(baseUrlAdapter.call()).thenReturn("https://granduni.buzzhives.com/satapp-beta/");
+
+    final Interceptor.Chain chain = mock(Interceptor.Chain.class);
+    final Request chainRequest = new Request.Builder()
+        .url("https://sydney-au-nsw-sydney.tripgo.skedgo.com/satapp/regions.json")
+        .build();
+    when(chain.request()).thenReturn(chainRequest);
+
+    final Request expectedRequest = chainRequest.newBuilder()
+        .url("https://granduni.buzzhives.com/satapp-beta/regions.json")
+        .build();
+    interceptor.intercept(chain);
+
+    verify(chain).proceed(argThat(new ArgumentMatcher<Request>() {
+      @Override public boolean matches(Object argument) {
+        final Request actualRequest = (Request) argument;
+        return actualRequest.url().equals(expectedRequest.url())
+            && actualRequest.method().equals(expectedRequest.method());
+      }
+    }));
+  }
+
+  @Test public void overrideSatappRequestWithQueryParams() throws IOException {
+    when(baseUrlAdapter.call()).thenReturn("https://granduni.buzzhives.com/satapp-beta/");
+
+    final Interceptor.Chain chain = mock(Interceptor.Chain.class);
+    final Request chainRequest = new Request.Builder()
+        .url(HttpUrl.parse("https://lepton-us-co-denver.tripgo.skedgo.com/satapp/routing.json?modes=ps_tax&v=11&arriveBefore=0&tt=0&departAfter=1459485056&version=a-beta4.5.1-debug"))
+        .build();
+    when(chain.request()).thenReturn(chainRequest);
+
+    final Request expectedRequest = chainRequest.newBuilder()
+        .url(HttpUrl.parse("https://granduni.buzzhives.com/satapp-beta/routing.json?modes=ps_tax&v=11&arriveBefore=0&tt=0&departAfter=1459485056&version=a-beta4.5.1-debug"))
+        .build();
+    interceptor.intercept(chain);
+
+    verify(chain).proceed(argThat(new ArgumentMatcher<Request>() {
+      @Override public boolean matches(Object argument) {
+        final Request actualRequest = (Request) argument;
+        return actualRequest.url().equals(expectedRequest.url())
+            && actualRequest.method().equals(expectedRequest.method());
+      }
+    }));
+  }
+
+  @Test public void ignoreNonSatappRequest() throws IOException {
+    when(baseUrlAdapter.call()).thenReturn("https://granduni.buzzhives.com/satapp-beta/");
+
+    final Interceptor.Chain chain = mock(Interceptor.Chain.class);
+    final Request chainRequest = new Request.Builder()
+        .url(HttpUrl.parse("https://skedgo.com/tripgo"))
+        .build();
+    when(chain.request()).thenReturn(chainRequest);
+
+    interceptor.intercept(chain);
+    verify(chain).proceed(same(chainRequest));
+  }
+
+  @Test public void ignoreIfNoNewBaseUrlAvailable() throws IOException {
+    when(baseUrlAdapter.call()).thenReturn(null);
+
+    final Interceptor.Chain chain = mock(Interceptor.Chain.class);
+    final Request chainRequest = new Request.Builder()
+        .url(HttpUrl.parse("https://skedgo.com/tripgo"))
+        .build();
+    when(chain.request()).thenReturn(chainRequest);
+
+    interceptor.intercept(chain);
+    verify(chain).proceed(same(chainRequest));
+  }
+}


### PR DESCRIPTION
`Configs` now exposes an optional `baseUrlAdapterFactory()` that allows to specify a base url that will supersede all the base urls that contain the `satapp` path segment.
