### PR TITLE
Add lint Options and package Options to enable Travis builds to pass.

### DIFF
--- a/trip-kit-account/build.gradle
+++ b/trip-kit-account/build.gradle
@@ -19,6 +19,14 @@ android {
       proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
     }
   }
+  lintOptions {
+    warning 'InvalidPackage'
+  }
+  // Exclude following files to avoid conflicts between Mockito and AssertJ.
+  packagingOptions {
+    exclude 'asm-license.txt'
+    exclude 'META-INF/services/com.google.gson.TypeAdapterFactory'
+  }
 }
 
 dependencies {

--- a/trip-kit-booking/build.gradle
+++ b/trip-kit-booking/build.gradle
@@ -23,11 +23,16 @@ android {
     }
   }
 
+  lintOptions {
+    warning 'InvalidPackage'
+  }
+
   // Exclude following files to avoid conflicts between Mockito and AssertJ.
   packagingOptions {
     exclude 'LICENSE'
     exclude 'NOTICE'
     exclude 'asm-license.txt'
+    exclude 'META-INF/services/com.google.gson.TypeAdapterFactory'
   }
 }
 

--- a/trip-kit/build.gradle
+++ b/trip-kit/build.gradle
@@ -20,6 +20,10 @@ android {
     }
   }
 
+  lintOptions{
+    warning 'InvalidPackage'
+  }
+
   packagingOptions {
     // To avoid conflicts between Mockito and AssertJ.
     exclude "LICENSE"


### PR DESCRIPTION
Add some lint configs and package configs to tripkit, tripkit-account, and tripkit-booking due to the fact that we now depends on modules instead of local maven.
