### PR TITLE
Introduce ExtraQueryMapProvider

### DIFF
--- a/trip-kit/src/main/java/com/skedgo/android/tripkit/Configs.java
+++ b/trip-kit/src/main/java/com/skedgo/android/tripkit/Configs.java
@@ -20,6 +20,7 @@ public abstract class Configs {
   @Nullable public abstract ExcludedTransitModesAdapter excludedTransitModesAdapter();
   @Nullable public abstract Func0<Co2Preferences> co2PreferencesFactory();
   @Nullable public abstract Func0<TripPreferences> tripPreferencesFactory();
+  @Nullable public abstract ExtraQueryMapProvider extraQueryMapProvider();
 
   /**
    * @return A factory to retrieve user token obtained via TripGo Account API.

--- a/trip-kit/src/main/java/com/skedgo/android/tripkit/ExtraQueryMapProvider.java
+++ b/trip-kit/src/main/java/com/skedgo/android/tripkit/ExtraQueryMapProvider.java
@@ -1,0 +1,20 @@
+package com.skedgo.android.tripkit;
+
+import android.support.annotation.NonNull;
+
+import java.util.Map;
+
+/**
+ * A decorator that puts additional query params
+ * into the query map that is supplied into {@link RoutingApi}.
+ * Note that you should only use this when
+ * you really do know what you intend to do.
+ */
+public interface ExtraQueryMapProvider {
+  /**
+   * Be careful that some entries of this map
+   * may override some default entries of
+   * the query map of {@link RoutingApi}.
+   */
+  @NonNull Map<String, Object> call();
+}

--- a/trip-kit/src/main/java/com/skedgo/android/tripkit/MainModule.java
+++ b/trip-kit/src/main/java/com/skedgo/android/tripkit/MainModule.java
@@ -150,6 +150,7 @@ class MainModule {
         configs.excludedTransitModesAdapter(),
         co2Preferences,
         tripPreferences,
+        configs.extraQueryMapProvider(),
         gson
     );
   }

--- a/trip-kit/src/main/java/com/skedgo/android/tripkit/RouteServiceImpl.java
+++ b/trip-kit/src/main/java/com/skedgo/android/tripkit/RouteServiceImpl.java
@@ -35,6 +35,7 @@ final class RouteServiceImpl implements RouteService {
   private final ExcludedTransitModesAdapter excludedTransitModesAdapter;
   @Nullable private final Co2Preferences co2Preferences;
   @Nullable private final TripPreferences tripPreferences;
+  @Nullable private final ExtraQueryMapProvider extraQueryMapProvider;
   private final Gson gson;
 
   RouteServiceImpl(
@@ -45,6 +46,7 @@ final class RouteServiceImpl implements RouteService {
       @Nullable ExcludedTransitModesAdapter excludedTransitModesAdapter,
       @Nullable Co2Preferences co2Preferences,
       @Nullable TripPreferences tripPreferences,
+      @Nullable ExtraQueryMapProvider extraQueryMapProvider,
       @NonNull Gson gson) {
     this.appVersion = appVersion;
     this.queryGenerator = queryGenerator;
@@ -53,6 +55,7 @@ final class RouteServiceImpl implements RouteService {
     this.excludedTransitModesAdapter = excludedTransitModesAdapter;
     this.co2Preferences = co2Preferences;
     this.tripPreferences = tripPreferences;
+    this.extraQueryMapProvider = extraQueryMapProvider;
     this.gson = gson;
   }
 
@@ -147,6 +150,10 @@ final class RouteServiceImpl implements RouteService {
     }
 
     options.putAll(getParamsByPreferences());
+    if (extraQueryMapProvider != null) {
+      final Map<String, Object> extraQueryMap = extraQueryMapProvider.call();
+      options.putAll(extraQueryMap);
+    }
     return options;
   }
 


### PR DESCRIPTION
### What's new in this pull request?

This patch introduces `ExtraQueryMapProvider`. This decorator class was born to avoid some direct modification on `RouteServiceImpl` just to try to add a `bsb=1` param into routing requests (thus violates the open/closed principle).

If a client of TripKit would like to add additional query params into routing requests, she would be able to inject an implementation of `ExtraQueryMapProvider` into `Configs` via `extraQueryMapProvider()`.
