### PR TITLE
ICalendarEvent needs to expose id()

### DIFF
--- a/android-shared-lib/src/main/java/com/skedgo/android/common/agenda/ICalendarEvent.java
+++ b/android-shared-lib/src/main/java/com/skedgo/android/common/agenda/ICalendarEvent.java
@@ -37,4 +37,5 @@ public interface ICalendarEvent extends ITimeRange {
   void setEffectiveTimeRange(ITimeRange effectiveTimeRange);
 
   String getUID();
+  int getId();
 }


### PR DESCRIPTION
This is for when users tap an event on the agenda page, we'll retrieve the id of the event and launch up the event editor for selected id.