### PR TITLE
Fix missing pre-filled values in Booking Form fields

### DIFF
--- a/trip-kit-booking-ui/src/main/java/com/skedgo/android/tripkit/booking/ui/view/PasswordFieldView.java
+++ b/trip-kit-booking-ui/src/main/java/com/skedgo/android/tripkit/booking/ui/view/PasswordFieldView.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import android.os.Build;
 import android.support.annotation.NonNull;
 import android.text.Editable;
+import android.text.TextUtils;
 import android.text.TextWatcher;
 import android.util.AttributeSet;
 import android.widget.EditText;
@@ -37,6 +38,9 @@ public class PasswordFieldView extends RelativeLayout {
   public void bindViewModel(@NonNull final PasswordFormField passwordField) {
     setVisibility(passwordField.isHidden() ? GONE : VISIBLE);
     editText.setHint(passwordField.getTitle());
+    if (!TextUtils.isEmpty(passwordField.getValue())) {
+      editText.setText(passwordField.getValue());
+    }
     editText.addTextChangedListener(
         new TextWatcher() {
           @Override

--- a/trip-kit-booking-ui/src/main/java/com/skedgo/android/tripkit/booking/ui/view/StringFieldView.java
+++ b/trip-kit-booking-ui/src/main/java/com/skedgo/android/tripkit/booking/ui/view/StringFieldView.java
@@ -51,12 +51,12 @@ public class StringFieldView extends RelativeLayout {
     }
     editText.setVisibility(stringField.isReadOnly() ? GONE : VISIBLE);
     if (!stringField.isReadOnly()) {
-      if (!stringField.isHidden()) {
-        stringField.setValue(editText.getText().toString());
-      }
       titleView.setVisibility(GONE);
       valueView.setVisibility(GONE);
       editText.setHint(stringField.getTitle());
+      if (!TextUtils.isEmpty(stringField.getValue())) {
+        editText.setText(stringField.getValue());
+      }
       editText.addTextChangedListener(new TextWatcher() {
         @Override public void beforeTextChanged(CharSequence s, int start, int count, int after) {}
 


### PR DESCRIPTION
### What's new in this PR?

Fix issue https://github.com/skedgo/tripgo-android/issues/1784

Booking form value was not set in edit texts. Also, this code was setting string fields to empty every time, as `editText.getText().toString()` is always empty on field creation:
```
     if (!stringField.isHidden()) {
        stringField.setValue(editText.getText().toString());
     }
```
