### PR TITLE
Re-add boolean-2-visibility converter

### DIFF
--- a/trip-kit-booking-ui/src/main/java/com/skedgo/android/tripkit/booking/ui/view/Converters.java
+++ b/trip-kit-booking-ui/src/main/java/com/skedgo/android/tripkit/booking/ui/view/Converters.java
@@ -1,0 +1,13 @@
+package com.skedgo.android.tripkit.booking.ui.view;
+
+import android.databinding.BindingConversion;
+import android.view.View;
+
+public final class Converters {
+  private Converters() {}
+
+  @BindingConversion
+  public static int convertBooleanToViewVisibility(boolean value) {
+    return value ? View.VISIBLE : View.GONE;
+  }
+}


### PR DESCRIPTION
This class was removed during the migration of RxLifecycleComponents. The class is part of the `common-views` library.