### PR TITLE
Remove observability on start & end time change for TripSegment

### DIFF
--- a/CommonCoreLegacy/src/main/java/com/skedgo/android/common/model/TripSegment.java
+++ b/CommonCoreLegacy/src/main/java/com/skedgo/android/common/model/TripSegment.java
@@ -25,7 +25,6 @@ import java.util.Locale;
 
 import rx.functions.Action1;
 import rx.functions.Actions;
-import rx.subjects.BehaviorSubject;
 
 import static com.skedgo.android.common.model.VehicleMode.createLightDrawable;
 
@@ -102,7 +101,6 @@ public class TripSegment implements Parcelable, IRealTimeElement, ITimeRange {
   private final transient Var<BitmapDrawable> remoteIcon = Var.create();
   private long mId;
   private transient Trip mTrip;
-  private transient BehaviorSubject<TripSegment> mWhenTimeChanged;
   @SerializedName("booking")
   private Booking booking;
   @SerializedName("modeInfo")
@@ -281,12 +279,7 @@ public class TripSegment implements Parcelable, IRealTimeElement, ITimeRange {
   }
 
   public void setStartTimeInSecs(long newStartTimeInSecs) {
-    if (newStartTimeInSecs != mStartTimeInSecs) {
-      mStartTimeInSecs = newStartTimeInSecs;
-
-      // Notify subscribers that time has changed.
-      whenTimeChanged().onNext(this);
-    }
+    mStartTimeInSecs = newStartTimeInSecs;
   }
 
   public void setMetresSafe(int metresSafe) {
@@ -303,12 +296,7 @@ public class TripSegment implements Parcelable, IRealTimeElement, ITimeRange {
   }
 
   public void setEndTimeInSecs(long newEndTimeInSecs) {
-    if (newEndTimeInSecs != mEndTimeInSecs) {
-      mEndTimeInSecs = newEndTimeInSecs;
-
-      // Notify subscribers that time has changed.
-      whenTimeChanged().onNext(this);
-    }
+    mEndTimeInSecs = newEndTimeInSecs;
   }
 
   @Deprecated
@@ -670,14 +658,6 @@ public class TripSegment implements Parcelable, IRealTimeElement, ITimeRange {
     } else {
       return true;
     }
-  }
-
-  public BehaviorSubject<TripSegment> whenTimeChanged() {
-    if (mWhenTimeChanged == null) {
-      mWhenTimeChanged = BehaviorSubject.create(this);
-    }
-
-    return mWhenTimeChanged;
   }
 
   public Var<List<ServiceStop>> stops() {

--- a/CommonCoreLegacy/src/main/java/com/skedgo/android/common/util/TripSegmentListResolver.java
+++ b/CommonCoreLegacy/src/main/java/com/skedgo/android/common/util/TripSegmentListResolver.java
@@ -13,8 +13,6 @@ import org.apache.commons.collections4.CollectionUtils;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 
-import rx.functions.Action1;
-
 /**
  * Puts a Departure segment before head of,
  * and puts an Arrival segment after tail of a segment list.
@@ -87,13 +85,6 @@ public class TripSegmentListResolver {
     arrivalSegment.setVisibility(TripSegment.VISIBILITY_ON_MAP);
     arrivalSegment.setStartTimeInSecs(lastSegment.getEndTimeInSecs());
     arrivalSegment.setEndTimeInSecs(lastSegment.getEndTimeInSecs());
-    lastSegment.whenTimeChanged().subscribe(new Action1<TripSegment>() {
-      @Override
-      public void call(TripSegment segment) {
-        arrivalSegment.setStartTimeInSecs(segment.getEndTimeInSecs());
-        arrivalSegment.setEndTimeInSecs(segment.getEndTimeInSecs());
-      }
-    });
     return arrivalSegment;
   }
 
@@ -121,13 +112,6 @@ public class TripSegmentListResolver {
     departureSegment.setVisibility(TripSegment.VISIBILITY_IN_DETAILS);
     departureSegment.setStartTimeInSecs(firstSegment.getStartTimeInSecs());
     departureSegment.setEndTimeInSecs(firstSegment.getStartTimeInSecs());
-    firstSegment.whenTimeChanged().subscribe(new Action1<TripSegment>() {
-      @Override
-      public void call(TripSegment segment) {
-        departureSegment.setStartTimeInSecs(segment.getStartTimeInSecs());
-        departureSegment.setEndTimeInSecs(segment.getStartTimeInSecs());
-      }
-    });
     return departureSegment;
   }
 

--- a/CommonCoreLegacy/src/test/java/com/skedgo/android/common/model/TripSegmentTest2.java
+++ b/CommonCoreLegacy/src/test/java/com/skedgo/android/common/model/TripSegmentTest2.java
@@ -17,9 +17,6 @@ import org.robolectric.annotation.Config;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicLong;
-
-import rx.functions.Action1;
 
 import static com.skedgo.android.common.model.TripSegment.VISIBILITY_HIDDEN;
 import static com.skedgo.android.common.model.TripSegment.VISIBILITY_IN_DETAILS;
@@ -96,58 +93,6 @@ public class TripSegmentTest2 {
     assertFalse(segment.isVisibleInContext(VISIBILITY_IN_SUMMARY));
     assertFalse(segment.isVisibleInContext(VISIBILITY_ON_MAP));
     assertFalse(segment.isVisibleInContext(VISIBILITY_HIDDEN));
-  }
-
-  @Test public void shouldNotifyStartTimeChangedEvent() {
-    TripSegment segment = new TripSegment();
-
-    // (M/D/Y @ h:m:s): 8 / 2 / 2002 @ 0:0:0 UTC
-    int expectedStartTimeInSecs1 = 1028246400;
-    segment.setStartTimeInSecs(expectedStartTimeInSecs1);
-
-    final AtomicLong timeRecorder = new AtomicLong();
-    segment.whenTimeChanged().subscribe(new Action1<TripSegment>() {
-      @Override
-      public void call(TripSegment segment) {
-        timeRecorder.set(segment.getStartTimeInSecs());
-      }
-    });
-
-    assertThat(timeRecorder.get())
-        .isEqualTo(expectedStartTimeInSecs1);
-
-    // (M/D/Y @ h:m:s): 8 / 1 / 2002 @ 0:0:0 UTC
-    int expectedStartTimeInSecs2 = 1028160000;
-    segment.setStartTimeInSecs(expectedStartTimeInSecs2);
-
-    assertThat(timeRecorder.get())
-        .isEqualTo(expectedStartTimeInSecs2);
-  }
-
-  @Test public void shouldNotifyEndTimeChangedEvent() {
-    TripSegment segment = new TripSegment();
-
-    // (M/D/Y @ h:m:s): 8 / 2 / 2002 @ 0:0:0 UTC
-    int expectedEndTimeInSecs1 = 1028246400;
-    segment.setEndTimeInSecs(expectedEndTimeInSecs1);
-
-    final AtomicLong timeRecorder = new AtomicLong();
-    segment.whenTimeChanged().subscribe(new Action1<TripSegment>() {
-      @Override
-      public void call(TripSegment segment) {
-        timeRecorder.set(segment.getEndTimeInSecs());
-      }
-    });
-
-    assertThat(timeRecorder.get())
-        .isEqualTo(expectedEndTimeInSecs1);
-
-    // (M/D/Y @ h:m:s): 8 / 1 / 2002 @ 0:0:0 UTC
-    int expectedEndTimeInSecs2 = 1028160000;
-    segment.setEndTimeInSecs(expectedEndTimeInSecs2);
-
-    assertThat(timeRecorder.get())
-        .isEqualTo(expectedEndTimeInSecs2);
   }
 
   /**

--- a/CommonCoreLegacy/src/test/java/com/skedgo/android/common/util/TripSegmentListResolverTest.java
+++ b/CommonCoreLegacy/src/test/java/com/skedgo/android/common/util/TripSegmentListResolverTest.java
@@ -4,9 +4,7 @@ import android.content.res.Resources;
 
 import com.skedgo.android.common.BuildConfig;
 import com.skedgo.android.common.TestRunner;
-import com.skedgo.android.common.model.Location;
 import com.skedgo.android.common.model.SegmentType;
-import com.skedgo.android.common.model.Trip;
 import com.skedgo.android.common.model.TripSegment;
 
 import org.junit.Before;
@@ -14,9 +12,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
-
-import java.util.ArrayList;
-import java.util.Arrays;
 
 import static com.skedgo.android.common.model.TripSegment.VISIBILITY_IN_DETAILS;
 import static com.skedgo.android.common.model.TripSegment.VISIBILITY_ON_MAP;
@@ -60,83 +55,5 @@ public class TripSegmentListResolverTest {
     assertThat(arrivalSegment.getStartTimeInSecs())
         .isEqualTo(arrivalSegment.getEndTimeInSecs())
         .isEqualTo(lastSegment.getEndTimeInSecs());
-  }
-
-  /**
-   * @see <a href="https://redmine.buzzhives.com/issues/4197">Issue 4197</a>
-   * @see <a href="https://redmine.buzzhives.com/issues/4397">Issue 4397</a>
-   */
-  @Test public void departureTimesBindsToFirstSegmentTimes() {
-    TripSegment firstSegment = new TripSegment();
-    firstSegment.setAction("Take MRT");
-    firstSegment.setStartTimeInSecs(2);
-    firstSegment.setEndTimeInSecs(3);
-
-    TripSegment finalSegment = new TripSegment();
-    finalSegment.setAction("Ride scooter");
-    finalSegment.setStartTimeInSecs(3);
-    finalSegment.setEndTimeInSecs(5);
-
-    Trip trip = new Trip();
-    trip.setSegments(new ArrayList<>(Arrays.asList(
-        firstSegment,
-        finalSegment
-    )));
-
-    resolver
-        .setOrigin(new Location())
-        .setDestination(new Location())
-        .setTripSegmentList(trip.getSegments())
-        .resolve();
-
-    firstSegment.setStartTimeInSecs(3);
-    firstSegment.setEndTimeInSecs(4);
-
-    TripSegment departureSegment = trip.getSegments().get(0);
-    assertThat(departureSegment.getStartTimeInSecs())
-        .describedAs("Departure segment's start time must be bound to first segment's start time")
-        .isEqualTo(firstSegment.getStartTimeInSecs());
-    assertThat(departureSegment.getEndTimeInSecs())
-        .describedAs("Departure segment's end time must be bound to first segment's start time")
-        .isEqualTo(firstSegment.getStartTimeInSecs());
-  }
-
-  /**
-   * @see <a href="https://redmine.buzzhives.com/issues/4197">Issue 4197</a>
-   * @see <a href="https://redmine.buzzhives.com/issues/4397">Issue 4397</a>
-   */
-  @Test public void arrivalTimesBindsToFinalSegmentTimes() {
-    TripSegment firstSegment = new TripSegment();
-    firstSegment.setAction("Take MRT");
-    firstSegment.setStartTimeInSecs(2);
-    firstSegment.setEndTimeInSecs(3);
-
-    TripSegment finalSegment = new TripSegment();
-    finalSegment.setAction("Ride scooter");
-    finalSegment.setStartTimeInSecs(3);
-    finalSegment.setEndTimeInSecs(5);
-
-    Trip trip = new Trip();
-    trip.setSegments(new ArrayList<>(Arrays.asList(
-        firstSegment,
-        finalSegment
-    )));
-
-    resolver
-        .setOrigin(new Location())
-        .setDestination(new Location())
-        .setTripSegmentList(trip.getSegments())
-        .resolve();
-
-    finalSegment.setStartTimeInSecs(4);
-    finalSegment.setEndTimeInSecs(5);
-
-    TripSegment arrivalSegment = trip.getSegments().get(trip.getSegments().size() - 1);
-    assertThat(arrivalSegment.getStartTimeInSecs())
-        .describedAs("Arrival segment's start time must be bound to final segment's end time")
-        .isEqualTo(finalSegment.getEndTimeInSecs());
-    assertThat(arrivalSegment.getEndTimeInSecs())
-        .describedAs("Arrival segment's end time must be bound to final segment's end time")
-        .isEqualTo(finalSegment.getEndTimeInSecs());
   }
 }


### PR DESCRIPTION
These pieces of code were previously written to adapt the old way of updating a `Trip` and its `TripSegment`s in realtime. Before, when we received realtime data, we mutated `TripSegment`'s start time & end time. That's why we added `WhenTimeChanged` into `TripSegment` so that UI side can be aware of the changes on start time & end time and act accordingly. But now, it no longer works with that way. When we receive realtime data which is a new `Trip`, we'll replace the old `Trip` with it. As a result, `WhenTimeChanged` is unnecessary any more.

I'm so glad we were able to ditch such evil mutability.