### PR TITLE
Upgrade Kotlin & Dagger

### DIFF
--- a/AccountData/build.gradle
+++ b/AccountData/build.gradle
@@ -23,23 +23,23 @@ android {
 }
 
 dependencies {
-  testCompile 'junit:junit:4.12'
+  testCompile libs.junit
   testCompile libs.assertjCore
   testCompile libs.mockitoCore
   testCompile libs.robolectric
   testCompile "com.squareup.okhttp3:mockwebserver:$okHttpVersion"
 
   compile 'com.android.support:support-annotations:25.2.0'
-  compile 'io.reactivex:rxjava:1.2.4'
+  compile libs.rxjava
   compile "com.squareup.retrofit2:retrofit:2.0.2"
   compile "com.squareup.retrofit2:converter-gson:2.0.2"
   compile "com.squareup.retrofit2:adapter-rxjava:2.0.2"
-  compile 'com.google.code.gson:gson:2.6.1'
+  compile libs.gson
   provided project(":AccountDomain")
   provided project(":TripKitDomain")
 
-  compile 'com.google.dagger:dagger:2.7'
-  kapt 'com.google.dagger:dagger-compiler:2.7'
+  compile libs.dagger
+  kapt libs.daggerCompiler
 
   // To generate immutable models.
   // See more at http://immutables.github.io/.

--- a/AccountDomain/build.gradle
+++ b/AccountDomain/build.gradle
@@ -10,14 +10,14 @@ targetCompatibility = '1.7'
 sourceCompatibility = '1.7'
 
 dependencies {
-  testCompile 'junit:junit:4.12'
+  testCompile libs.junit
   testCompile libs.assertjCore
   testCompile libs.mockitoCore
   testCompile libs.mockitoKotlin, { exclude group: 'org.jetbrains.kotlin' }
 
-  compile 'io.reactivex:rxjava:1.2.4'
-  compile 'com.google.dagger:dagger:2.7'
-  kapt 'com.google.dagger:dagger-compiler:2.7'
+  compile libs.rxjava
+  compile libs.dagger
+  kapt libs.daggerCompiler
 
   compile libs.kotlin
   compileOnly project(":TripKitDomain")

--- a/CommonCoreLegacy/build.gradle
+++ b/CommonCoreLegacy/build.gradle
@@ -49,7 +49,7 @@ dependencies {
   androidTestCompile 'com.android.support.test:runner:0.5'
   androidTestCompile 'com.android.support.test:rules:0.5'
 
-  testCompile 'junit:junit:4.12'
+  testCompile libs.junit
   testCompile libs.assertjCore
   testCompile libs.robolectric
   testCompile 'commons-io:commons-io:2.5'
@@ -63,9 +63,9 @@ dependencies {
   compile 'com.android.support:support-annotations:25.3.0'
   compile libs.playServicesMaps
   compile libs.jodaTimeAndroid
-  compile 'io.reactivex:rxjava:1.2.4'
+  compile libs.rxjava
   compile 'io.reactivex:rxandroid:1.2.1', { exclude module: 'rxjava' }
-  compile 'com.google.code.gson:gson:2.6.1'
+  compile libs.gson
   compile 'com.github.skedgo:commons-collections:v1.0'
 
   compile project(':TripKitDomain')

--- a/TripKitAndroid/build.gradle
+++ b/TripKitAndroid/build.gradle
@@ -39,7 +39,7 @@ task(generateTripkitStrings, type: org.gradle.api.tasks.JavaExec) {
 }
 
 dependencies {
-  testCompile 'junit:junit:4.12'
+  testCompile libs.junit
   testCompile libs.assertjCore
   testCompile libs.robolectric
   testCompile libs.mockitoCore
@@ -59,8 +59,8 @@ dependencies {
   compile "com.squareup.retrofit2:adapter-rxjava:2.0.2"
   compile "com.squareup.retrofit2:retrofit:2.0.2"
 
-  compile 'com.google.dagger:dagger:2.7'
-  kapt 'com.google.dagger:dagger-compiler:2.7'
+  compile libs.dagger
+  kapt libs.daggerCompiler
   kapt libs.value
   provided libs.valueAnnotations
   provided libs.builderAnnotations

--- a/TripKitAndroid/src/main/java/skedgo/tripkit/android/A2bRoutingComponent.kt
+++ b/TripKitAndroid/src/main/java/skedgo/tripkit/android/A2bRoutingComponent.kt
@@ -3,12 +3,11 @@ package skedgo.tripkit.android
 import dagger.Subcomponent
 import skedgo.tripkit.a2brouting.GetA2bRoutingResults
 import skedgo.tripkit.a2brouting.GetTripLine
-import javax.inject.Singleton
 
 /**
  * Creates UseCases and Repositories related to the A2bRouting feature.
  */
-@Singleton
+@FeatureScope
 @Subcomponent
 interface A2bRoutingComponent {
   val getA2bRoutingResults: GetA2bRoutingResults

--- a/TripKitAndroid/src/main/java/skedgo/tripkit/android/AnalyticsComponent.kt
+++ b/TripKitAndroid/src/main/java/skedgo/tripkit/android/AnalyticsComponent.kt
@@ -3,12 +3,11 @@ package skedgo.tripkit.android
 import dagger.Subcomponent
 import skedgo.tripkit.analytics.AnalyticsDataModule
 import skedgo.tripkit.analytics.MarkTripAsPlannedWithUserInfo
-import javax.inject.Singleton
 
 /**
  * Creates UseCases and Repositories related to the Analytics feature.
  */
-@Singleton
+@FeatureScope
 @Subcomponent(modules = arrayOf(
     AnalyticsDataModule::class
 ))

--- a/TripKitAndroid/src/main/java/skedgo/tripkit/android/DateTimeComponent.kt
+++ b/TripKitAndroid/src/main/java/skedgo/tripkit/android/DateTimeComponent.kt
@@ -4,12 +4,11 @@ import dagger.Subcomponent
 import skedgo.tripkit.datetime.DateTimeDataModule
 import skedgo.tripkit.datetime.PrintFullDate
 import skedgo.tripkit.datetime.PrintTime
-import javax.inject.Singleton
 
 /**
  * Creates UseCases and Repositories related to the DateTime feature.
  */
-@Singleton
+@FeatureScope
 @Subcomponent(modules = arrayOf(
     DateTimeDataModule::class
 ))

--- a/TripKitAndroid/src/main/java/skedgo/tripkit/android/FeatureScope.kt
+++ b/TripKitAndroid/src/main/java/skedgo/tripkit/android/FeatureScope.kt
@@ -1,0 +1,7 @@
+package skedgo.tripkit.android
+
+import javax.inject.Scope
+
+@Scope
+@Retention(AnnotationRetention.RUNTIME)
+annotation class FeatureScope

--- a/TripKitData/build.gradle
+++ b/TripKitData/build.gradle
@@ -23,7 +23,7 @@ android {
 }
 
 dependencies {
-  testCompile "junit:junit:4.12"
+  testCompile libs.junit
   testCompile libs.assertjCore
   testCompile libs.mockitoCore
   testCompile libs.mockitoKotlin, { exclude group: "org.jetbrains.kotlin" }
@@ -31,8 +31,8 @@ dependencies {
 
   compile project(":TripKitDomain")
   compile project(":TripKitDomainLegacy")
-  compile "com.google.dagger:dagger:2.7"
-  kapt "com.google.dagger:dagger-compiler:2.7"
+  compile libs.dagger
+  kapt libs.daggerCompiler
   kapt libs.value
   provided libs.valueAnnotations
   provided libs.builderAnnotations

--- a/TripKitDomain/build.gradle
+++ b/TripKitDomain/build.gradle
@@ -11,15 +11,15 @@ targetCompatibility = '1.7'
 sourceCompatibility = '1.7'
 
 dependencies {
-  testCompile 'junit:junit:4.12'
+  testCompile libs.junit
   testCompile libs.assertjCore
   testCompile libs.mockitoCore
   testCompile libs.mockitoKotlin, { exclude group: 'org.jetbrains.kotlin' }
 
   compile libs.jodaTime
-  compile 'io.reactivex:rxjava:1.2.4'
-  compile 'com.google.dagger:dagger:2.7'
-  kapt 'com.google.dagger:dagger-compiler:2.7'
+  compile libs.rxjava
+  compile libs.dagger
+  kapt libs.daggerCompiler
 
   compile libs.kotlin
   kapt libs.value

--- a/TripKitDomainLegacy/build.gradle
+++ b/TripKitDomainLegacy/build.gradle
@@ -24,8 +24,8 @@ android {
 
 dependencies {
   compile project(":TripKitDomain")
-  compile 'com.google.dagger:dagger:2.7'
-  kapt 'com.google.dagger:dagger-compiler:2.7'
+  compile libs.dagger
+  kapt libs.daggerCompiler
   kapt libs.value
   provided libs.valueAnnotations
   provided libs.builderAnnotations

--- a/TripKitSamples/build.gradle
+++ b/TripKitSamples/build.gradle
@@ -30,7 +30,7 @@ android {
 }
 
 dependencies {
-  testCompile 'junit:junit:4.12'
+  testCompile libs.junit
   compile libs.kotlin
   compile 'com.android.support:appcompat-v7:25.3.0'
   compile 'com.android.support:recyclerview-v7:25.3.0'

--- a/ValidBookingCountData/build.gradle
+++ b/ValidBookingCountData/build.gradle
@@ -23,18 +23,18 @@ android {
 }
 
 dependencies {
-  testCompile 'junit:junit:4.12'
+  testCompile libs.junit
   testCompile libs.robolectric
   testCompile libs.mockitoKotlin, { exclude group: 'org.jetbrains.kotlin' }
 
-  compile 'io.reactivex:rxjava:1.2.4'
+  compile libs.rxjava
   compile "com.squareup.retrofit2:retrofit:2.0.2"
   compile "com.squareup.retrofit2:converter-gson:2.0.2"
   compile "com.squareup.retrofit2:adapter-rxjava:2.0.2"
-  compile 'com.google.code.gson:gson:2.6.1'
+  compile libs.gson
 
-  compile 'com.google.dagger:dagger:2.7'
-  kapt 'com.google.dagger:dagger-compiler:2.7'
+  compile libs.dagger
+  kapt libs.daggerCompiler
 
   // To generate immutable models.
   // See more at http://immutables.github.io/.

--- a/ValidBookingCountDomain/build.gradle
+++ b/ValidBookingCountDomain/build.gradle
@@ -10,16 +10,16 @@ targetCompatibility = '1.7'
 sourceCompatibility = '1.7'
 
 dependencies {
-  testCompile 'junit:junit:4.12'
+  testCompile libs.junit
   testCompile libs.assertjCore
   testCompile libs.mockitoCore
   testCompile libs.mockitoKotlin, { exclude group: 'org.jetbrains.kotlin' }
   testCompile project(":AccountDomain")
 
   compile libs.kotlin
-  compile 'io.reactivex:rxjava:1.2.4'
-  compile 'com.google.dagger:dagger:2.7'
-  kapt 'com.google.dagger:dagger-compiler:2.7'
+  compile libs.rxjava
+  compile libs.dagger
+  kapt libs.daggerCompiler
 
   // Use `compileOnly` to achieve similar effect of `provided` scope.
   // See more https://blog.gradle.org/introducing-compile-only-dependencies.

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -13,7 +13,7 @@ libVersions.buildToolsVersion = "25.0.2"
 libVersions.targetSdkVersion = 22
 libVersions.playServicesVersion = "10.2.1"
 libVersions.firebaseAppIndexingVersion = "10.2.1"
-libVersions.kotlinVersion = "1.1.2-2"
+libVersions.kotlinVersion = "1.1.2-3"
 ext.libVersions = libVersions
 
 Expando libs = new Expando()
@@ -27,12 +27,11 @@ libs.jodaTimeTzdb = "joda-time:joda-time:2.9.9"
 libs.jodaTimeAndroid = "net.danlew:android.joda:2.9.9"
 libs.multidex = "com.android.support:multidex:1.0.1"
 libs.androidJob = "com.evernote:android-job:1.1.8"
-libs.androidReactiveLocation = "com.github.skedgo:Android-ReactiveLocation:8f7e161e61815fee3d6a76d950ef0e1f44ede42f"
+libs.androidReactiveLocation = "com.github.skedgo:Android-ReactiveLocation:636ef5d15581b54b60fb5ace003b812cc84c413a"
 libs.playServicesMaps = "com.google.android.gms:play-services-maps:$libVersions.playServicesVersion"
 libs.playServicesLocation = "com.google.android.gms:play-services-location:$libVersions.playServicesVersion"
 libs.playServicesAnalytics = "com.google.android.gms:play-services-analytics:$libVersions.playServicesVersion"
 libs.playServicesGcm = "com.google.android.gms:play-services-gcm:$libVersions.playServicesVersion"
-libs.playServicesPlaces = "com.google.android.gms:play-services-places:$libVersions.playServicesVersion"
 libs.firebaseAppIndexing = "com.google.firebase:firebase-appindexing:$libVersions.firebaseAppIndexingVersion"
 
 libs.value = "org.immutables:value:$libVersions.immutablesVersion"

--- a/route-persistence/build.gradle
+++ b/route-persistence/build.gradle
@@ -40,7 +40,7 @@ dependencies {
   compile project(':TripKitAndroid')
   compile 'com.github.skedgo:sqlite-utils:v1.0'
 
-  testCompile 'junit:junit:4.12'
+  testCompile libs.junit
   testCompile libs.assertjCore
   testCompile libs.mockitoCore
   testCompile libs.robolectric

--- a/trip-kit-booking-ui/build.gradle
+++ b/trip-kit-booking-ui/build.gradle
@@ -25,7 +25,7 @@ android {
 }
 
 dependencies {
-  testCompile 'junit:junit:4.12'
+  testCompile libs.junit
   testCompile libs.assertjCore
   testCompile libs.mockitoCore
   testCompile libs.robolectric
@@ -42,8 +42,8 @@ dependencies {
   compile 'uk.co.chrisjenx:calligraphy:2.1.0'
   compile 'com.github.skedgo:robotos:v1.1'
 
-  compile 'com.google.dagger:dagger:2.7'
-  kapt 'com.google.dagger:dagger-compiler:2.7'
+  compile libs.dagger
+  kapt libs.daggerCompiler
 
   compile 'com.squareup.picasso:picasso:2.5.2'
   compile 'com.jakewharton.picasso:picasso2-okhttp3-downloader:1.0.2'

--- a/trip-kit-booking/build.gradle
+++ b/trip-kit-booking/build.gradle
@@ -28,7 +28,7 @@ android {
 }
 
 dependencies {
-  testCompile 'junit:junit:4.12'
+  testCompile libs.junit
   testCompile libs.assertjCore
   testCompile libs.mockitoCore
   testCompile libs.robolectric
@@ -36,8 +36,8 @@ dependencies {
 
   compile project(':TripKitAndroid')
 
-  compile 'com.google.dagger:dagger:2.7'
-  annotationProcessor 'com.google.dagger:dagger-compiler:2.7'
+  compile libs.dagger
+  annotationProcessor libs.daggerCompiler
 
   // To generate immutable models.
   // See more at http://immutables.github.io/.


### PR DESCRIPTION
# what
* Upgrades to Kotlin v1.1.2-3 & Dagger v2.10. Build was broken after that. Dagger v2.10 wouldn't accept parent Component & sub component having the same scope which is `@Singleton`. So `@FeatureScope` was born.