### PR TITLE
Fix address not appear as reverse geocoding result

### DIFF
--- a/TripKitAndroid/src/main/java/com/skedgo/android/tripkit/AndroidGeocoder.kt
+++ b/TripKitAndroid/src/main/java/com/skedgo/android/tripkit/AndroidGeocoder.kt
@@ -14,7 +14,7 @@ class AndroidGeocoder(private val context: Context) : Geocodable {
         .map { addresses ->
           // See http://developer.android.com/training/location/display-address.html.
           val address = addresses[0]
-          val addressLines = arrayOfNulls<String>(address.maxAddressLineIndex)
+          val addressLines = arrayOfNulls<String>(address.maxAddressLineIndex + 1)
           for (i in addressLines.indices) {
             addressLines[i] = address.getAddressLine(i)
           }


### PR DESCRIPTION
### What is new in this Pull Request?

This PR changes `address.getMaxAddressLineIndex()` to `address.getMaxAddressLineIndex() + 1` because we use the index as the length of the new array