### PR TITLE
Fix configuration error

### DIFF
--- a/TripKitSamples/build.gradle
+++ b/TripKitSamples/build.gradle
@@ -42,6 +42,7 @@ dependencies {
   implementation libs.rxjava
   implementation libs.rxAndroid
   kapt libs.dataBindingCompiler
+  annotationProcessor libs.dataBindingCompiler
 
   implementation libs.rxLifecycleComponents
   implementation libs.bindingCollectionAdapterRecyclerView


### PR DESCRIPTION
> TripKitSamples: 'annotationProcessor' dependencies won't be recognized as kapt annotation processors. Please change the configuration name to 'kapt' for these artifacts: 'com.android.databinding:compiler:3.0.1'.

To Fix