### PR TITLE
[20604] Ticket update on logout and signing in with a different user fix

### DIFF
--- a/TripKitAndroid/src/main/java/com/skedgo/tripkit/AddCustomHeaders.kt
+++ b/TripKitAndroid/src/main/java/com/skedgo/tripkit/AddCustomHeaders.kt
@@ -45,8 +45,10 @@ class AddCustomHeaders constructor(
             is Key.RegionEligibility -> builder.addHeader(regionEligibilityHeader, key.value)
         }
 
-        if (getUserToken?.call() != null) {
-            builder.addHeader(userTokenHeader, getUserToken.call())
+        getUserToken?.call()?.let { token ->
+            if (token.isNotEmpty()) {
+                builder.addHeader(userTokenHeader, token)
+            }
         }
 
         val hasTripSelection = preferences?.getBoolean("tripSelection", false) ?: false


### PR DESCRIPTION
- [TripGoV5] Handle ActiveBookingItem visibility on user logout. 
- [TripKit]Adjust AddCustomHeaders to not include empty token
- [TripGov5] check initiation in onresume for HomeBottomSheetItemManagers
- [TripKitUI] Add custom binding in CustomBinding.kt for handling view visibility by height setting
- [TripGov5] update HomeBottomSheetItemManager and add flag for including HomeItemSpacer when added to home cards
- [TripGov5] update parameters for TransitTicketItemManager and only include token provider instead of having both token provider and user account repository
- [TripGov5] Update TripGoAccountSettingsManager to add common fun clear auth and update child classes accordingly
- [TripGov5] update transit_ticket_item.xml for handling visibility (by height) when ticket polling is active
- [TripGov5] handle on resume to check if auth token is available and if polling is active to toggle card visibility and re-run polling if different user