### PR TITLE
[20619] DRT booking with not ticket fix & [20734] Ticket api call spam fix

### DIFF
--- a/trip-kit-booking/src/main/java/com/skedgo/tripkit/booking/quickbooking/QuickBooking.kt
+++ b/trip-kit-booking/src/main/java/com/skedgo/tripkit/booking/quickbooking/QuickBooking.kt
@@ -17,7 +17,7 @@ data class QuickBooking(
     val input: List<Input>,
     val title: String,
     val tripUpdateURL: String,
-    @SerializedName("fares") val fares: List<Fare>,
+    @SerializedName("fares") val fares: List<Fare>? = emptyList(),
     val billingEnabled: Boolean,
     val riders: List<Rider>
 )


### PR DESCRIPTION
- [TripGov5] update DrtFragment and include hasTickets field on PaymentData
- [TripGov5] update DrtViewModel and remove enableBooking liveData since the usage is wrong and also update the logic for valid input checking
- [TripGov5] update HomeBottomSheetFragment to handle onPause for HomeBottomSheetItemManagers pause state
- [TripKit] update QuickBooking to make fares nullable
- [TripGov5] update TransitTicketItem to handle cancelling on pause and running polling on resume