### PR TITLE
[20424] User induction screens. [20792] Fix active trip and wallet visibility on user logout

### DIFF
--- a/TripKitAndroid/src/main/java/com/skedgo/tripkit/Configs.java
+++ b/TripKitAndroid/src/main/java/com/skedgo/tripkit/Configs.java
@@ -73,4 +73,6 @@ public interface Configs {
 
     @Value.Default public default boolean showGeofences() { return false;}
 
+    @Value.Default public default boolean hasInductionCards() { return false;}
+
 }

--- a/TripKitAndroid/src/main/java/com/skedgo/tripkit/TripKitConstants.kt
+++ b/TripKitAndroid/src/main/java/com/skedgo/tripkit/TripKitConstants.kt
@@ -8,6 +8,7 @@ class TripKitConstants {
         const val PREF_NAME_APP = "app_preferences"
         const val PREF_KEY_TRIP_KIT_LAT_LNG = "pref_key_trip_kit_lat_lng"
         const val PREF_KEY_POLYGON = "pref_key_polygon"
+        const val PREF_KEY_CLIENT_FEATURES = "pref_key_client_features"
     }
 
 }

--- a/TripKitAndroid/src/main/java/com/skedgo/tripkit/data/TripKitSharedPreference.kt
+++ b/TripKitAndroid/src/main/java/com/skedgo/tripkit/data/TripKitSharedPreference.kt
@@ -3,6 +3,8 @@ package com.skedgo.tripkit.data
 import android.annotation.SuppressLint
 import android.content.Context
 import android.content.SharedPreferences
+import com.google.gson.Gson
+import com.skedgo.tripkit.TripKitConstants.Companion.PREF_KEY_CLIENT_FEATURES
 import com.skedgo.tripkit.TripKitConstants.Companion.PREF_KEY_CLIENT_ID
 import com.skedgo.tripkit.TripKitConstants.Companion.PREF_KEY_POLYGON
 import com.skedgo.tripkit.TripKitConstants.Companion.PREF_KEY_TRIP_KIT_LAT_LNG
@@ -30,6 +32,15 @@ class TripKitSharedPreference @Inject constructor(context: Context) : BaseShared
 
     fun getClientId(): String? =
         sharedPreferences.getString(PREF_KEY_CLIENT_ID, null)
+
+    fun saveClientFeatures(features: List<String>) {
+        sharedPreferences.edit()
+            .putString(PREF_KEY_CLIENT_FEATURES, Gson().toJson(features))
+            .apply()
+    }
+
+    fun getClientFeatures(): List<String> =
+        Gson().fromJson(sharedPreferences.getString(PREF_KEY_CLIENT_FEATURES, null) ?: "")
 
     fun savePolygon(polygon: Polygon?) {
         sharedPreferences.edit()

--- a/TripKitData/src/main/java/com/skedgo/tripkit/account/data/Client.kt
+++ b/TripKitData/src/main/java/com/skedgo/tripkit/account/data/Client.kt
@@ -7,8 +7,11 @@ data class Client(
     var clientName: String,
     val polygon: Polygon? = null,
     val appColors: AppColors? = null,
-    var isBeta: Boolean = false
-)
+    var isBeta: Boolean = false,
+    val features: List<String>? = emptyList()
+) {
+    fun hasWalletFeature(): Boolean = features?.any { it == ClientFeature.WALLET.feature } ?: false
+}
 
 data class AppColors(
     val barBackground: BarBackground,
@@ -46,3 +49,7 @@ data class TintColor(
     val green: Int,
     val red: Int
 )
+
+enum class ClientFeature(val feature: String) {
+    WALLET("WALLET")
+}


### PR DESCRIPTION
- [TripGov5] Fix ActiveBookingItemViewModel visibility and data fetching when user logged in and out.   
- [TripGov5] Add info/help icon for showing induction screen on ActiveBookingItemViewModel
- [TripGov5] Update AppSelectionFragment to cache client features and reset auth checking after selecting a region
- [TripGov5] Fix BalanceItemViewModel visibility when user logged in and out
- [TripGov5] Add info/help icon for showing induction screen on BalanceItemViewModel
- [TripKit] Update Client.kt to handle features field 
- [TripGov5] update HomeFragment to handle logic for induction home cards visibility and induction screens pop-up
- [TripGov5] new HomeInductionCardItemManager and HomeInductionCardItem for handling induction home cards
- [TripGov5] add new HomeViewModel for new logic and to handle all logics from HomeFragment in the future
- [TripGov5] Add InductionActivity and InductionFragment for induction screens pop-up
- [TripGov5] Update MobilityBundleHomeItem and MobilityBundleItemManager to fix visibility when user logged in and out
- [TripKitUI] update trip_result_list_fragment.xml to add info/help view for triggering induction screen
- [TripGov5] update TripGoSharedPreference to caching induction related data
- [TripKit] update TripKitSharedPreference to cache client features