### PR TITLE
[20933] Stripe payment flow fix

### DIFF
--- a/trip-kit-booking/src/main/java/com/skedgo/tripkit/booking/quickbooking/QuickBookingPaymentIntent.kt
+++ b/trip-kit-booking/src/main/java/com/skedgo/tripkit/booking/quickbooking/QuickBookingPaymentIntent.kt
@@ -6,5 +6,6 @@ data class QuickBookingPaymentIntent(
     val url: String,
     val stripeApiKey: String? = null,
     val updateURL: String? = null,
-    val type: String? = null
+    val type: String? = null,
+    val internalPaymentIntentFetched: Boolean = false
 )


### PR DESCRIPTION
- [TripGov5] update fragment_ticket_payment.xml and remove click databinding as using TapStateFlow has some delays
- [TripGov5] update PaymentSummaryFragment and add validation for internal paymentMode checking and if paymentIntent is already fetched
- [TripGov5]update PaymentSummaryViewModel and set fields properly from the new payment intent for internal paymentMode
- [TripKit] update QuickBookingPaymentIntent and add internalPaymentIntentFetched to act as a flag if the internal payment intent was already fetched.
- [TripGov5] update TripTicketPaymentFragment and update the flow for the stripe payment