### PR TITLE
[20775] Handle SchoolLocation on geocode.json result

### DIFF
--- a/CommonCoreLegacy/src/main/java/com/skedgo/tripkit/common/model/Location.java
+++ b/CommonCoreLegacy/src/main/java/com/skedgo/tripkit/common/model/Location.java
@@ -68,6 +68,8 @@ public class Location implements Parcelable {
      */
     public static final int TYPE_W3W = 9;
 
+    public static final int TYPE_SCHOOL = 11;
+
     public static final int NO_BEARING = Integer.MAX_VALUE;
     public static final double ZERO_LAT = 0.0;
     public static final double ZERO_LON = 0.0;
@@ -113,6 +115,10 @@ public class Location implements Parcelable {
 
             List<RouteDetails> routes = new ArrayList<>();
             in.readTypedList(routes, RouteDetails.CREATOR);
+
+            List<String> modeIdentifiers = new ArrayList<>();
+            in.readList(modeIdentifiers, String.class.getClassLoader());
+            location.modeIdentifiers = modeIdentifiers;
 
             return location;
         }
@@ -175,6 +181,8 @@ public class Location implements Parcelable {
     private boolean withExternalApp;
     private List<Operator> operators;
     private List<RouteDetails> routes;
+
+    private List<String> modeIdentifiers;
 
     public Location() {
         lat = ZERO_LAT;
@@ -483,6 +491,14 @@ public class Location implements Parcelable {
         this.operators = operators;
     }
 
+    public List<String> getModeIdentifiers() {
+        return modeIdentifiers;
+    }
+
+    public void setModeIdentifiers(List<String> modeIdentifiers) {
+        this.modeIdentifiers = modeIdentifiers;
+    }
+
     /**
      * Get the distance between this and another point
      * <p/>
@@ -568,6 +584,7 @@ public class Location implements Parcelable {
         out.writeString(region);
         out.writeTypedList(operators);
         out.writeTypedList(routes);
+        out.writeList(modeIdentifiers);
     }
 
     /**

--- a/CommonCoreLegacy/src/main/java/com/skedgo/tripkit/common/model/LocationConstants.kt
+++ b/CommonCoreLegacy/src/main/java/com/skedgo/tripkit/common/model/LocationConstants.kt
@@ -1,0 +1,3 @@
+package com.skedgo.tripkit.common.model
+
+const val LOCATION_CLASS_SCHOOL = "SchoolLocation"

--- a/CommonCoreLegacy/src/main/java/com/skedgo/tripkit/common/model/TransportMode.java
+++ b/CommonCoreLegacy/src/main/java/com/skedgo/tripkit/common/model/TransportMode.java
@@ -22,7 +22,7 @@ public class TransportMode {
   public static final String ID_SHUFFLE = "ps_shu";
   public static final String ID_TNC = "ps_tnc";
   public static final String ID_BICYCLE = "cy_bic";
-  public static final String ID_SCHOOL_BUS = "pt_sch";
+  public static final String ID_SCHOOL_BUS = "pt_ltd_SCHOOLBUS";
   public static final String ID_PUBLIC_TRANSPORT = "pt_pub";
   public static final String ID_MOTORBIKE = "me_mot";
   public static final String ID_CAR = "me_car";
@@ -62,7 +62,7 @@ public class TransportMode {
       return R.drawable.ic_public_transport;
     } else if (ID_TAXI.equals(identifier)) {
       return R.drawable.ic_taxi;
-    } else if (ID_SHUTTLE_BUS.equals(identifier)) {
+    } else if (ID_SHUTTLE_BUS.equals(identifier) || ID_SCHOOL_BUS.equals(identifier)) {
       return R.drawable.ic_shuttlebus;
     } else if (ID_MOTORBIKE.equals(identifier)) {
       return R.drawable.ic_motorbike;

--- a/TripKitAndroid/src/main/java/com/skedgo/tripkit/QueryGeneratorImpl.kt
+++ b/TripKitAndroid/src/main/java/com/skedgo/tripkit/QueryGeneratorImpl.kt
@@ -1,5 +1,6 @@
 package com.skedgo.tripkit
 
+import com.skedgo.tripkit.common.model.LOCATION_CLASS_SCHOOL
 import com.skedgo.tripkit.common.model.Query
 import com.skedgo.tripkit.common.model.TransportMode
 import com.skedgo.tripkit.data.regions.RegionService
@@ -40,7 +41,18 @@ internal class QueryGeneratorImpl(private val regionService: RegionService) : Qu
                         allTransportModes.add(TransportMode.ID_WHEEL_CHAIR)
                     }
 
-                    val filteredTransportModes = allTransportModes.filter { transportModeFilter.useTransportMode(it) }
+                    val filteredTransportModes = allTransportModes
+                        .filter { transportModeFilter.useTransportMode(it) }.toMutableList()
+
+                    if(departure.locationClass == LOCATION_CLASS_SCHOOL ||
+                        arrival.locationClass == LOCATION_CLASS_SCHOOL) {
+                        val modeIdentifiers = (departure.modeIdentifiers.orEmpty() + arrival.modeIdentifiers.orEmpty())
+                            .toSet().toList()
+
+                        filteredTransportModes.remove(TransportMode.ID_SCHOOL_BUS)
+                        filteredTransportModes.addAll(modeIdentifiers)
+                    }
+
                     query.transportModeIds = filteredTransportModes
                     regionService.getTransportModesAsync()
                 }


### PR DESCRIPTION
## Ticket
#### Support for "schools" returned by `geocode.json` (Android)
- https://redmine.buzzhives.com/issues/20775

## Changes

- [TripKitUI] update AutoCompleteTaskModule and remove @Binds for FetchTripGoLocations
- [TripKitUI] add AutoCompleteTaskProvidesModule for databinding FetchTripGoLocations since we added TransportModeSharedPreference on constructing FetchTripGoLocationsImpl
- [TripKitUI] update FetchTripGoLocationsImpl set locationType to Location.TYPE_SCHOOL if locationClass is "SchoolLocation". Also checking if pt_ltd_SCHOOLBUS is enabled before including in the search result
- [TripKit] update Location to handle modeIdentifiers from "SchoolLocation" class and add new type TYPE_SCHOOL
- [TripKitUI] update LocationSearchIconProvider to add handling for SCHOOL icon from results
- [TripKitUI] update QueryGeneratorImpl to replace pt_ltd_SCHOOLBUS with modeIdentifiers for routing.json query
- [TripKitUI] update SuggestionViewModel to add getting of icon for Location.TYPE_SCHOOL
- [TripKitUI] update TransportMode and add handling for SCHOOL
- [TripKitUI] add TransportModeSharedPreference to handle all transport mode related caching on shared pref
- [TripGov5] update TripGoLocationSearchIconProvider to add handling for SCHOOL icon