### PR TITLE
[21295] Update scoring strategy for search results with modeIdentifiers

### DIFF
--- a/TripKitAndroid/src/main/java/com/skedgo/geocoding/GCSkedgoResult.java
+++ b/TripKitAndroid/src/main/java/com/skedgo/geocoding/GCSkedgoResult.java
@@ -1,8 +1,12 @@
 package com.skedgo.geocoding;
 
 
+import androidx.annotation.Nullable;
+
 import com.skedgo.geocoding.agregator.GCSkedGoResultInterface;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
 
 public class GCSkedgoResult extends GCResult implements GCSkedGoResultInterface {
 
@@ -12,10 +16,21 @@ public class GCSkedgoResult extends GCResult implements GCSkedGoResultInterface 
 //  popularity json field from skedgo's json
     private int popularity;
 
-    public GCSkedgoResult(String name, double lat, double lng, @NotNull String resultClass, Integer popularity ){
+    @Nullable
+    private List<String> modeIdentifiers;
+
+    public GCSkedgoResult(
+            String name,
+            double lat,
+            double lng,
+            @NotNull String resultClass,
+            Integer popularity,
+            @Nullable List<String> modeIdentifiers
+    ){
         super(name, lat, lng);
         this.popularity = popularity;
         this.resultClass = resultClass;
+        this.modeIdentifiers = modeIdentifiers;
     }
 
     @NotNull
@@ -39,5 +54,11 @@ public class GCSkedgoResult extends GCResult implements GCSkedGoResultInterface 
 
     public boolean isStopLocation(){
         return this.resultClass.equalsIgnoreCase("StopLocation");
+    }
+
+    @Nullable
+    @Override
+    public List<String> getModeIdentifiers() {
+        return modeIdentifiers;
     }
 }

--- a/TripKitAndroid/src/main/java/com/skedgo/geocoding/agregator/GCSkedGoResultInterface.java
+++ b/TripKitAndroid/src/main/java/com/skedgo/geocoding/agregator/GCSkedGoResultInterface.java
@@ -1,5 +1,9 @@
 package com.skedgo.geocoding.agregator;
 
+import androidx.annotation.Nullable;
+
+import java.util.List;
+
 public interface GCSkedGoResultInterface extends GCResultInterface {
 
 //    skedgo result class (class json field)
@@ -7,4 +11,6 @@ public interface GCSkedGoResultInterface extends GCResultInterface {
 //    skedgo result popularity (popularity json field)
     int getPopularity();
 
+    @Nullable
+    List<String> getModeIdentifiers();
 }

--- a/TripKitAndroid/src/main/java/com/skedgo/geocoding/agregator/MultiSourceGeocodingAggregator.java
+++ b/TripKitAndroid/src/main/java/com/skedgo/geocoding/agregator/MultiSourceGeocodingAggregator.java
@@ -194,7 +194,10 @@ public class MultiSourceGeocodingAggregator<T extends GCResultInterface> {
 //            int popularityScore = (Math.min(popularity, GOOD_SCORE)) / (GOOD_SCORE / 100)
             int popularityScore = ((Math.min(popularity, GOOD_SCORE)) / (GOOD_SCORE / 100)) * 2;
 
-            popularityScore = GeocodeUtilities.rangedScoreForScore(popularityScore, 30, 80);
+            popularityScore = (candidate.getModeIdentifiers() != null && !candidate.getModeIdentifiers().isEmpty()) ?
+                    GeocodeUtilities.rangedScoreForScore(popularityScore, 50, 90) :
+                    GeocodeUtilities.rangedScoreForScore(popularityScore, 30, 80);
+
             if (popularity > GOOD_SCORE) {
                 int moreThanGood = popularityScore / GOOD_SCORE;
                 int bonus = GeocodeUtilities.rangedScoreForScore(moreThanGood, 0, 10);
@@ -208,7 +211,9 @@ public class MultiSourceGeocodingAggregator<T extends GCResultInterface> {
             if (!query.getQueryText().isEmpty()){
                 int nameScore = GeocodeUtilities.scoreBasedOnNameMatchBetweenSearchTerm(query.getQueryText(), candidate.getName());
 
-                int totalScore = GeocodeUtilities.rangedScoreForScore(nameScore,0,50);
+                int totalScore = (candidate.getModeIdentifiers() != null && !candidate.getModeIdentifiers().isEmpty()) ?
+                        GeocodeUtilities.rangedScoreForScore(nameScore,50,90):
+                        GeocodeUtilities.rangedScoreForScore(nameScore,0,50);
                 scoringResult.setScore(totalScore);
                 scoringResult.setNameScore(nameScore);
                 return scoringResult;
@@ -284,71 +289,4 @@ public class MultiSourceGeocodingAggregator<T extends GCResultInterface> {
 
         return scoringResult;
     }
-
-//    private List<MGAResultInterface<T>> removeDuplicates(List<MGAResultInterface<T>> list) {
-//        int count = list.size();
-//        List<MGAResultInterface<T>> withoutDuplicates = new ArrayList<>();
-//        for (int i = 0; i < count; i++) {
-//            GroupScoringResult groupScoringResult;
-//            ScoringResult scoringResult;
-//            if (list.get(i) instanceof ScoringResult) {
-//                groupScoringResult = new GroupScoringResult();
-//                groupScoringResult.addDuplicate((ScoringResult) list.get(i));
-//                scoringResult = (ScoringResult) list.get(i);
-//            }
-//            else{
-//                groupScoringResult = (GroupScoringResult) list.get(i);
-//                scoringResult = (ScoringResult) groupScoringResult.getDuplicates().get(0);
-//            }
-//
-//            for (int j = i + 1; j < count; j++) {
-//                if (scoringResult.equals(list.get(j))) {
-//                    if (list.get(j) instanceof ScoringResult)
-//                        groupScoringResult.addDuplicate((ScoringResult) list.get(j));
-//                    else
-//                        groupScoringResult.addDuplicates(list.get(j).getDuplicates());
-//                    list.remove(j--);
-//                    count--;
-//                }
-//            }
-//            withoutDuplicates.add(i, groupScoringResult);
-//        }
-//        return GeocodeUtilities.sortByScore(withoutDuplicates);
-//    }
-
-
-//    private List<MGAResultInterface<T>> removeDuplicates(List<MGAResultInterface<T>> list) {
-//
-//        Set<MGAResultInterface<T>> treeSet = new TreeSet<>(new Comparator<MGAResultInterface<T>>() {
-//            @Override
-//            public int compare(MGAResultInterface<T> o1, MGAResultInterface<T> o2) {
-//                ScoringResult<T> scoringResult = (ScoringResult<T>) o1.getClassRepresentative();
-//                if (scoringResult.equals(o2)){
-//                    GroupScoringResult<T> o1Group = (GroupScoringResult<T>) o1;
-//                    if (!o1.equals(o2)) {
-//                        GroupScoringResult<T> o2Group = (GroupScoringResult<T>) o2;
-//                        List<MGAResultInterface<T>> o1Duplicates = new ArrayList<>(o1Group.getDuplicates());
-//                        o1Group.addDuplicates(new ArrayList<>(o2Group.getDuplicates()));
-//                        o2Group.addDuplicates(o1Duplicates);
-//
-//                    }
-//                }
-//                return scoringResult.equals(o2)  ? 0 : 1;
-//            }
-//        });
-//
-//        for (MGAResultInterface<T> o : list){
-//            GroupScoringResult<T> groupScoringResult;
-//            if (o instanceof ScoringResult) {
-//                groupScoringResult = new GroupScoringResult();
-//                groupScoringResult.addDuplicate((ScoringResult<T>) o);
-//            }
-//            else{
-//                groupScoringResult = (GroupScoringResult<T>) o;
-//            }
-//            treeSet.add(groupScoringResult);
-//        }
-//
-//        return new ArrayList<MGAResultInterface<T>>(treeSet);
-//    }
 }


### PR DESCRIPTION
## Ticket
- [Score schools from geocoding higher](https://redmine.buzzhives.com/issues/21295)

## Changes
- [TripKitUI] update FetchTripGoLocationsImpl to pass modeIdentifiers on SkedgoResultLocationAdapter
- [TripKit] update GCSkedGoResultInterface and GCSkedgoResult to add handling for modeIdentifiers field
- [TripKit] update MultiSourceGeocodingAggregator to add logic for increasing score range if candidate has modeIdentifiers
- [TripKitUI] update SkedgoResultLocationAdapter to add handling for modeIdentifiers