### PR TITLE
[19921] lit routing issues fix 

### DIFF
--- a/TripKitAndroid/src/main/java/com/skedgo/tripkit/a2brouting/GetTravelledLineForTrip.kt
+++ b/TripKitAndroid/src/main/java/com/skedgo/tripkit/a2brouting/GetTravelledLineForTrip.kt
@@ -47,9 +47,7 @@ class GetTravelledLineForTrip @Inject constructor() {
                         else
                             it.serviceColor.color
                         val decodedWayPoints = PolyUtil.decode(it.encodedWaypoints)
-                        println("tag123, a: ${decodedWayPoints.size}")
                         val simplified = decodedWayPoints.simplify(LAT_LNG_SIMPLIFY_TOLERANCE)
-                        println("tag123, b: ${simplified.size}")
                         simplified.zipWithNext()
                             .map { (start, end) ->
                                 com.skedgo.tripkit.LineSegment(
@@ -70,8 +68,10 @@ class GetTravelledLineForTrip @Inject constructor() {
                             .map { (start, end) ->
                                 var lineColor =
                                     (getColorForWheelchairAndBicycle(street, modeId) ?: color)
-                                if (!street.roadTags().isNullOrEmpty()) {
-                                    lineColor = Color.BLUE
+                                street.roadTags()?.let {
+                                    it.firstOrNull()?.let {
+                                        lineColor = it.getRoadTagColor()
+                                    }
                                 }
                                 com.skedgo.tripkit.LineSegment(
                                     TripKitLatLng(start.latitude, start.longitude),


### PR DESCRIPTION
### Ticket 

[Lit route routing - Android - fix issues and align with iOS and Web](https://redmine.buzzhives.com/issues/19921)

### Changes

- [TripKit] update GetTravelledLineForTrip to use roadTags colors when available for street segments
- [TripKitUI] update TripResultMapContributor and refactor on how data are being observed. Also move the logic for observing the mapTiles availability
- [TripKitUI] update TripResultMapViewModel and refactor how selected trip and its data is being observed and handled
- [TripKitUI] update TripSegmentListFragment and remove the mapTiles handling from there
- [TripKitUI] update item_fake_graph.xml to display vertical lines for mid and max values
- [TripKitUI] update item_road_tag_chart.xml and set progress bar background to transparent so it'll not cut the vertical lines.