### PR TITLE
[23264] Fixed issue with time diff that is less than 1 resulting in empty time string equivalent

### DIFF
--- a/CommonCoreLegacy/src/main/java/com/skedgo/tripkit/common/util/TimeUtils.kt
+++ b/CommonCoreLegacy/src/main/java/com/skedgo/tripkit/common/util/TimeUtils.kt
@@ -105,22 +105,26 @@ object TimeUtils {
         time: String
     ): String {
         var time = time
-        if (hour == 1) {
-            time += hour.toString() + " " + context.getString(R.string.str_hr)
-        } else if (hour > 1) {
-            time += hour.toString() + " " + context.getString(R.string.str_hrs)
+
+        // Add hours if present
+        if (hour > 0) {
+            time += context.resources.getQuantityString(
+                R.plurals.str_hours,
+                hour,
+                hour
+            )
         }
 
-        if (minutes == 1) {
-            if (hour >= 1) {
-                time += " "
+        // Add minutes if present
+        if (minutes > 0) {
+            if (hour > 0) {
+                time += " " // Add space between hours and minutes
             }
-            time += minutes.toString() + " " + context.getString(R.string.str_mins)
-        } else if (minutes > 1) {
-            if (hour >= 1) {
-                time += " "
-            }
-            time += minutes.toString() + " " + context.getString(R.string.str_mins)
+            time += context.resources.getQuantityString(
+                R.plurals.str_minutes,
+                minutes,
+                minutes
+            )
         }
 
         return time
@@ -129,6 +133,10 @@ object TimeUtils {
     fun getDurationInHoursMins(context: Context, seconds: Int): String {
         val hour = seconds / InSeconds.HOUR
         val minutes = (seconds % InSeconds.HOUR) / InSeconds.MINUTE
+        // Explicitly handle durations less than 1 minute
+        if (hour == 0 && minutes == 0) {
+            return context.getString(R.string.str_less_than_min) // New string resource
+        }
         val time = ""
         return getHrsAndMinsString(context, hour, minutes, time)
     }

--- a/CommonCoreLegacy/src/main/res/values/strings.xml
+++ b/CommonCoreLegacy/src/main/res/values/strings.xml
@@ -40,6 +40,17 @@
     <string name="str_mins">mins</string>
     <string name="str_hr">hrs</string>
     <string name="str_hrs">hrs</string>
+
+    <plurals name="str_hours">
+        <item quantity="one">%d hr</item>
+        <item quantity="other">%d hrs</item>
+    </plurals>
+
+    <plurals name="str_minutes">
+        <item quantity="one">%d min</item>
+        <item quantity="other">%d mins</item>
+    </plurals>
+    <string name="str_less_than_min">1 min</string>
     <string name="direction">Direction</string>
 
     <string name="geofence_not_available">Geofence service is not available now</string>


### PR DESCRIPTION
# Pull Request (PR) Checklist

Thank you for your contribution! Please confirm that you've checked all the boxes below before submitting your PR. Use `[x]` to check a box, e.g., `[x]`, and make sure there's no space around the brackets.

## PR Context

- **Type**: Bug Fix
- **Issue Link**: [Some early bus notifications are missing the number of minutes they are early](https://redmine.buzzhives.com/issues/23264)
- **Risk Factor**: Low

## Changes

_Describe your changes in detail, highlighting the problem it solves or the feature it adds._
- Fixed issue with time diff that is less than 1 resulting in empty time string equivalent

## Checklist for Reviewers

### Documentation and Code Quality
- [x] **KDocs Documentation**: Are all changes, new functionalities, and classes documented with KDocs?
- [x] **Architectural Patterns**: Is there consistent and proper use of architectural patterns (e.g., MVVM, MVP)?

### Testing and Reliability
- [ ] **Unit Testing**: Are there unit tests for all new functionalities and classes?
- [x] **Emulator and Real Device Testing**: Has the application been tested on both emulators and real devices to ensure compatibility?

### Error Handling and Logging
- [x] **Error Handling**: Are errors and exceptions caught and handled gracefully, ensuring the app remains stable?
- [ ] **Logging**: Is there proper logging in place for critical errors and information, aiding in debugging and monitoring?
