### PR TITLE
[24705] - Fix hash code validation for stop caching

### DIFF
--- a/TripKitData/src/main/java/com/skedgo/tripkit/data/locations/StopsFetcher.kt
+++ b/TripKitData/src/main/java/com/skedgo/tripkit/data/locations/StopsFetcher.kt
@@ -54,7 +54,7 @@ open class StopsFetcher(
             .flatMap { existingCells ->
                 splitIntoBodiesForNewFetchOrUpdate(
                     cellIds,
-                    emptyList(), //existingCells
+                    existingCells, // Fix: Use existing cells to enable hash code validation for performance
                     region,
                     level
                 )


### PR DESCRIPTION
## PR Context

- **Type**: Bug Fix
- **Issue Link**: [MyWay+: Android app showing decommissioned stop](https://redmine.buzzhives.com/issues/24705)
- **Risk Factor**: Low

## Changes
- Enable hash code validation by using existingCells instead of emptyList()
- Allows backend to return 'no changes' when hash codes match
- Reduces bandwidth usage when users move map frequently

## Checklist for Reviewers

### Documentation and Code Quality
- [x] **KDocs Documentation**: Are all changes, new functionalities, and classes documented with KDocs?
- [x] **Architectural Patterns**: Is there consistent and proper use of architectural patterns (e.g., MVVM, MVP)?

### Testing and Reliability
- [ ] **Unit Testing**: Are there unit tests for all new functionalities and classes?
- [x] **Emulator and Real Device Testing**: Has the application been tested on both emulators and real devices to ensure compatibility?

### Error Handling and Logging
- [x] **Error Handling**: Are errors and exceptions caught and handled gracefully, ensuring the app remains stable?
- [x] **Logging**: Is there proper logging in place for critical errors and information, aiding in debugging and monitoring?


## Testing Procedure

**Step 1: Prepare for Marker Deletion**

1. Launch the app on the beta server.
3. Locate and interact with the marker stop (the "fake stop") you want to remove. This interaction forces the app to register that the stop should no longer exist.

**Step 2: Switch to the Production Environment**

1. Enable Developer Options in the app settings.
3. In the Developer Options menu, change the server environment to "Production".
5. Exit the Developer Options page.

**Step 3: Verify and Clear the Cache**

1. Observe the map: The marker will likely still appear on the map at this point. This is expected because the app initially pulls the stop from a local database cache.
3. Manually close and restart the app completely (do not just minimize it).
5. The Stop is Removed: On the next launch, the app will run the production server logic before checking the database, and the stop should no longer show on the map.

