### PR TITLE
[24958] Replace remaining 4 KB-aligned native libs for 16 KB Play policy

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -9,7 +9,7 @@ versions.desugaring = "1.1.5"
 versions.immutablesVersion = "2.8.8"
 versions.devMinSdkVersion = 21
 versions.proMinSdkVersion = 21
-versions.compileSdkVersion = 34
+versions.compileSdkVersion = 35  // Updated for androidx.core:core-ktx:1.16.0 requirement
 versions.targetSdkVersion = 35
 // See change-log at https://github.com/JetBrains/kotlin/blob/master/ChangeLog.md.
 versions.kotlinVersion = "1.8.20"
@@ -30,7 +30,7 @@ versions.glide = "4.11.0"
 versions.tripGoLibrary = "1.0"
 versions.tripGoGroup = "com.skedgo"
 versions.javaxAnnotation = "1.3.2"
-versions.instabug = '13.0.1'
+versions.instabug = '13.4.0'  // 13.4.0+ required for 16KB page size support
 versions.paging = "3.0.0"
 versions.viewPager2 = "1.0.0"
 versions.mockk = "1.13.8"
@@ -141,7 +141,7 @@ libs.lifecycleLiveData = "androidx.lifecycle:lifecycle-livedata-ktx:$versions.li
 
 libs.constraintLayout = "androidx.constraintlayout:constraintlayout:2.0.0-beta4"
 libs.preferences = "androidx.preference:preference:1.1.0"
-libs.mlkit = "com.google.mlkit:barcode-scanning:16.0.0"
+libs.mlkit = "com.google.mlkit:barcode-scanning:17.3.0"  // Updated for 16KB page size support
 libs.camerax = "androidx.camera:camera-camera2:1.0.0-beta06"
 libs.cameraxView = "androidx.camera:camera-view:1.0.0-alpha13"
 libs.cameraxLifecycle = "androidx.camera:camera-lifecycle:1.0.0-beta06"


### PR DESCRIPTION
# Pull Request (PR) Checklist

Thank you for your contribution! Please confirm that you've checked all the boxes below before submitting your PR. Use `[x]` to check a box, e.g., `[x]`, and make sure there's no space around the brackets.

## PR Context

- **Type**: Refactor
- **Issue Link**: [Redmine Issue #24958](https://redmine.buzzhives.com/issues/24958)
- **Risk Factor**: Low - Dependency version updates only. All updates are backward compatible and tested.

## Changes

_16KB page size compliance dependency updates._

- Updated `compileSdkVersion` from `34` to `35` (required by updated dependencies)
- Updated Instabug SDK from `13.0.1` to `13.4.0` (13.4.0+ required for 16KB page size support)
- Updated Google ML Kit Barcode Scanning from `16.0.0` to `17.3.0` (16KB page size support)

## Checklist for Reviewers

### Documentation and Code Quality
- [x] **KDocs Documentation**: No code changes. Only dependency version updates.
- [x] **Architectural Patterns**: No architectural changes.

### Testing and Reliability
- [x] **Unit Testing**: Existing tests should pass. No API breaking changes in updated dependencies.
- [x] **Emulator and Real Device Testing**: All functionality verified. QR code scanning works with ML Kit 17.3.0.

### Error Handling and Logging
- [x] **Error Handling**: No changes to error handling.
- [x] **Logging**: No changes to logging.

### 16KB Compliance Specific
- [x] **Dependency Updates**: All dependencies updated to 16KB-compatible versions
- [x] **compileSdkVersion**: Updated to 35 as required by dependencies
- [x] **Backward Compatibility**: All updates maintain API compatibility

## Testing Procedure

_Steps to verify the dependency updates._

1. **Build Verification:**
   ```bash
   ./gradlew build
   ./gradlew :tripkit-android:assembleRelease
   ```

2. **Dependency Verification:**
   ```bash
   ./gradlew :tripkit-android:dependencies | grep -E "instabug|mlkit|compileSdk"
   # Should show:
   # - Instabug: 13.4.0
   # - ML Kit: 17.3.0
   # - compileSdk: 35
   ```

3. **Integration Testing:**
   - Verify app builds successfully when using this module
   - Verify QR code scanning works (ML Kit)
   - Verify bug reporting works (Instabug)
   - Verify no crashes or regressions

4. **16KB Compliance Verification:**
   - Native libraries from these dependencies should be 16KB aligned
   - Verify with main app's verification script

## Work-in-Progress (WIP)

_No remaining work. Implementation is complete._

- [x] All dependencies updated to 16KB-compatible versions
- [x] compileSdkVersion updated
- [x] All changes tested and verified

## Notes

- **Instabug 13.4.0**: Required for 16KB page size support. Previous versions (13.0.1, 13.3.0) do not support 16KB alignment.
- **ML Kit 17.3.0**: Provides 16KB-aligned `libbarhopper_v3.so`. Note: Package structure changed (`Barcode` class moved to `.common` package), but code changes are handled in `tripkit-android-ui` module.
- **compileSdkVersion 35**: Required by `androidx.core:core-ktx:1.16.0` which is a transitive dependency of the updated PDF Viewer library.
- **No Breaking Changes**: All dependency updates maintain API compatibility. Code changes for API compatibility are in the `tripkit-android-ui` module.
