### PR TITLE
[25670] Reorder OkHttp interceptors to fix IllegalStateException: closed in HttpLoggingInterceptor

### DIFF
--- a/TripKitAndroid/src/main/java/com/skedgo/tripkit/HttpClientModule.kt
+++ b/TripKitAndroid/src/main/java/com/skedgo/tripkit/HttpClientModule.kt
@@ -44,14 +44,7 @@ open class HttpClientModule(
     open fun httpClient(addCustomHeaders: AddCustomHeaders): OkHttpClient {
         val builder = httpClientBuilder()
             .addInterceptor(addCustomHeaders)
-        if (configs.debuggable()) {
-            val interceptor = HttpLoggingInterceptor()
-            interceptor.level = HttpLoggingInterceptor.Level.BODY
-            builder.addInterceptor(interceptor)
-        }
-        if(BuildConfig.DEBUG || useInstabugNetworkInterceptor) {
-            builder.addInterceptor(InstabugOkhttpInterceptor())
-        }
+
         if (configs.baseUrlAdapterFactory() != null) {
             try {
                 builder.addInterceptor(BaseUrlOverridingInterceptor(configs.baseUrlAdapterFactory()!!))
@@ -62,6 +55,20 @@ open class HttpClientModule(
         builder.addInterceptor(
             errorInterceptor ?: ErrorHandlingInterceptor(appDeactivatedListener)
         )
+
+        // Instabug and HttpLoggingInterceptor must be added after all business-logic
+        // interceptors so they observe the final response. Instabug is added first so
+        // that the logging interceptor — which buffers the response body — runs last in
+        // the response path and never encounters a source that was already consumed.
+        if (BuildConfig.DEBUG || useInstabugNetworkInterceptor) {
+            builder.addInterceptor(InstabugOkhttpInterceptor())
+        }
+        if (configs.debuggable()) {
+            val loggingInterceptor = HttpLoggingInterceptor()
+            loggingInterceptor.level = HttpLoggingInterceptor.Level.BODY
+            builder.addInterceptor(loggingInterceptor)
+        }
+
         builder.connectTimeout(60, TimeUnit.SECONDS)
         builder.readTimeout(60, TimeUnit.SECONDS)
         builder.writeTimeout(60, TimeUnit.SECONDS)


### PR DESCRIPTION
## PR Context

- **Type**: Bug Fix
- **Issue Link**: [java.lang.IllegalStateException: closed in HttpLoggingInterceptor
](https://redmine.buzzhives.com/issues/25670)
- **Risk Factor**: Low 

## Changes

_Describe your changes in detail, highlighting the problem it solves or the feature it adds._

- Move InstabugOkhttpInterceptor and HttpLoggingInterceptor after all business-logic interceptors so the logging interceptor runs last in the response path and never encounters a body source already consumed by Instabug.

### Documentation and Code Quality
- [x] **KDocs Documentation**: Are all changes, new functionalities, and classes documented with KDocs?
- [x] **Architectural Patterns**: Is there consistent and proper use of architectural patterns (e.g., MVVM, MVP)?

### Testing and Reliability
- [ ] **Unit Testing**: Are there unit tests for all new functionalities and classes?
- [x] **Emulator and Real Device Testing**: Has the application been tested on both emulators and real devices to ensure compatibility?

### Error Handling and Logging
- [x] **Error Handling**: Are errors and exceptions caught and handled gracefully, ensuring the app remains stable?
- [x] **Logging**: Is there proper logging in place for critical errors and information, aiding in debugging and monitoring?

## Testing Procedure

_If applicable, provide steps or commands for testing your changes. This can help reviewers and testers._

- Launch the app
- Navigate through the app triggering API calls (search for a route, open timetables, view trip results)
- Verify: No IllegalStateException: closed crash in Logcat; HTTP request/response bodies are logged normally by HttpLoggingInterceptor

